### PR TITLE
mix docs task improvements

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,22 +2,27 @@ defmodule Nerves.Hub.Mixfile do
 
   use Mix.Project
 
-  def project, do: [
-    app: :nerves_hub,
-    version: version,
-    elixir: "~> 1.0",
-    source_url: "https://github.com/nerves-project/hub",
-    homepage_url: "http://nerves-project.org/",
-    deps: deps
-  ]
+  def project do
+    [app: :nerves_hub,
+     description: "Heirarchical key-value state store with pub-sub semantics",
+     version: version,
+     elixir: "~> 1.0",
+     deps: deps,
+     # ExDoc
+     name: "Hub",
+     docs: [main: Nerves.Hub,
+            source_url: "https://github.com/nerves-project/hub",
+            homepage_url: "http://nerves-project.org/",
+            extras: ["README.md", "CONTRIBUTING.md", "HISTORY.md"]]]
+  end
 
-  def application, do: [
-    mod: { Nerves.Hub, []}
-  ]
+  def application do
+    [mod: {Nerves.Hub, []}]
+  end
 
   defp deps, do: [
-    {:earmark, "~> 0.1", only: :dev},
-    {:ex_doc, "~> 0.8", only: :dev}
+    {:earmark, "~> 0.1.19", only: :dev},
+    {:ex_doc, "~> 0.10", only: :dev}
   ]
 
   defp version do

--- a/mix.lock
+++ b/mix.lock
@@ -1,0 +1,2 @@
+%{"earmark": {:hex, :earmark, "0.1.19"},
+  "ex_doc": {:hex, :ex_doc, "0.10.0"}}


### PR DESCRIPTION
This PR includes the following improvements:
- Add the missing `mix.lock` file
- Fix some options for `ExDoc`
- Include new options for `ExDoc` (extras, specify the main module instead of the API Reference)
- Update the version of the dependencies
- Improve `mix.exs` format
